### PR TITLE
Delete bootstrapping artifact

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-**What programming language should we add?**
-
-**What is the official website for the language?**
-
-**Is this a language that comes in many variants? If so, which variant should we support?**
-
-**Is there a testing framework available for the language?**
-
-**Who will be leading the effort to launch the track?**


### PR DESCRIPTION
I forgot to delete the exercism/request-new-language-track issue
template as part of the script that bootstraps new repositories.

This is fixed in the upstream script, so it shouldn't happen again
for new language tracks.