### PR TITLE
Add lib/generate.vim

### DIFF
--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,5 @@
+policies:
+  ProhibitCommandWithUnintendedSideEffect:
+    enabled: false
+  ProhibitCommandRelyOnUser:
+    enabled: false

--- a/config.json
+++ b/config.json
@@ -74,8 +74,9 @@
   "deprecated": [],
   "ignored": [
     "bin",
+    "docs",
     "img",
-    "docs"
+    "lib"
   ],
   "foregone": []
 }

--- a/lib/generate.vim
+++ b/lib/generate.vim
@@ -1,0 +1,85 @@
+"
+" This Vim script fetches the canonical test data for an
+" exercise from GitHub and converts it to a Vader file.
+"
+"   :source %
+"   :Generate word-count
+"
+
+function! s:data_url(slug) abort
+  return printf('https://raw.githubusercontent.com/exercism/x-common/master/exercises/%s/canonical-data.json', a:slug)
+endfunction
+
+function! s:generate_header(data)
+  call append(0, [
+        \ '"',
+        \ '" Version: '. a:data.version,
+        \ '"',
+        \ '',
+        \ 'Before:',
+        \ '  unlet! input expected',
+        \ ])
+endfunction
+
+function! s:generate_variable(name, value)
+  let value = a:value
+  if type(a:value) == type('')
+    let value = '"'. value .'"'
+  endif
+  return printf('  let %s = %s', a:name, value)
+endfunction
+
+function! s:generate_assert(property) abort
+  let funcname = toupper(a:property[0]) . a:property[1:]
+  return printf('  AssertEqual expected, %s(input)', funcname)
+endfunction
+
+function! s:get_input_value(test) abort
+  let t = copy(a:test)
+  if has_key(t, 'comments')    | call remove(t, 'comments')    | endif
+  if has_key(t, 'description') | call remove(t, 'description') | endif
+  if has_key(t, 'expected')    | call remove(t, 'expected')    | endif
+  if has_key(t, 'property')    | call remove(t, 'property')    | endif
+  return items(t)[0][1]
+endfunction
+
+function! s:generate_tests(tests) abort
+  for test in a:tests
+    if has_key(test, 'cases')
+      call s:generate_tests(test.cases)
+    else
+      call append(line('$'), printf('Execute (%s):', test.description))
+      call append(line('$'), s:generate_variable('input', s:get_input_value(test)))
+      call append(line('$'), s:generate_variable('expected', test.expected))
+      call append(line('$'), [s:generate_assert(test.property), ''])
+    endif
+  endfor
+endfunction
+
+function! s:replace_types() abort
+  silent %substitute/v:true/1/eg
+  silent %substitute/v:false/0/eg
+  silent %substitute/v:null/''/eg
+endfunction
+
+function! s:generate(slug) abort
+  execute 'silent edit' s:data_url(a:slug)
+  if getline(1) ==# '404: Not Found'
+    silent bwipeout!
+    redraw!
+    echomsg '404: Not Found'
+    return
+  endif
+  %yank x
+  let data = json_decode(substitute(@x, '\\', '\\\\', 'g'))
+  bwipeout!
+  enew!
+  setfiletype vader
+  call s:generate_header(data)
+  call s:generate_tests(data.cases)
+  call s:replace_types()
+  set nomodified
+  redraw!
+endfunction
+
+command! -nargs=1 Generate call s:generate(<f-args>)


### PR DESCRIPTION
This is a simple generator script.

It fetches the canonical data for an exercise from the web and converts it to a Vader file. It simply prints to stdout, so it can be piped to wherever it's needed.

It's quite hacky but worked for my local tests. I expect it to fail in some cases when the values of Ruby arrays/hashes aren't properly converted to their Vim equivalents.

But there's no need to make it perfect right now. Let's improve it incrementally. Whenever someone adds a new exercise, this script should be used for bootstrapping. If something goes wrong, it should be fixed.